### PR TITLE
Fix: Center SVG content in table cells

### DIFF
--- a/src/components/compare/ComparisonRow.tsx
+++ b/src/components/compare/ComparisonRow.tsx
@@ -44,9 +44,11 @@ const ComparisonRow: React.FC<ComparisonRowProps> = ({
         return (
           <td 
             key={property.id} 
-            className={`p-4 border-b border-gray-100 text-center ${getCellBackground()}`}
+            className={`p-4 border-b border-gray-100 text-center align-middle ${getCellBackground()}`}
           >
-            {valueType === 'boolean' ? renderBooleanValue(value) : value}
+            <div className="flex items-center justify-center w-full h-full">
+              {valueType === 'boolean' ? renderBooleanValue(value) : value}
+            </div>
           </td>
         );
       })}


### PR DESCRIPTION
- Keep inner div wrapper for reliable SVG centering
- Maintains compatibility with mixed content types